### PR TITLE
Add Whisper, NLLB, and MT5 workflow for Turkic audio summarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
 # Turkic Audio Summarizer
 
 This repository contains a Gradio application that transcribes Turkic-language audio,
-translates the transcription into a target language, and generates an abstractive
-summary of the translation using Hugging Face models.
+translates the transcription into English, and generates an abstractive summary of the
+translation using Hugging Face models.
 
 ## Features
 
 - **Automatic Speech Recognition:** Powered by [`openai/whisper-small`](https://huggingface.co/openai/whisper-small).
-- **Neural Machine Translation:** Backed by the [`facebook/m2m100_418M`](https://huggingface.co/facebook/m2m100_418M) multilingual model.
-- **Summarization:** Uses [`facebook/bart-large-cnn`](https://huggingface.co/facebook/bart-large-cnn) to condense translated text. The
-  app always summarizes an English rendition of the transcript to match the
-  summarizer's training data while still returning the user-selected
-  translation.
+- **Neural Machine Translation:** Backed by [`facebook/nllb-200-distilled-600M`](https://huggingface.co/facebook/nllb-200-distilled-600M) to convert Turkic text into English.
+- **Summarization:** Uses the MT5-based [`csebuetnlp/mT5_m2m_crossSum`](https://huggingface.co/csebuetnlp/mT5_m2m_crossSum) model to condense the translated text.
 - **Turkic language support:** Choose among Turkish, Azerbaijani, Kazakh, Uzbek, Tatar, Kyrgyz, Turkmen, and Uyghur inputs.
 - **Gradio UI:** Simple web interface for uploading audio or recording via a microphone.
 
@@ -53,4 +50,4 @@ summary of the translation using Hugging Face models.
 
 - The models used are large; for best performance run on a GPU-enabled environment.
 - Whisper will automatically detect the spoken language, but select the closest Turkic option to guide translation quality.
-- The summarizer expects English input. Selecting a different translation target may require swapping the summarization model.
+- Translation is always performed into English to match the summarization model's expectations.

--- a/colab_app.py
+++ b/colab_app.py
@@ -7,8 +7,8 @@ Usage inside Colab:
 !python colab_app.py
 ```
 
-The script preloads the required Hugging Face pipelines and launches a
-public Gradio share suitable for notebooks.
+The script preloads the required Hugging Face pipelines (Whisper, NLLB, and MT5)
+and launches a public Gradio share suitable for notebooks.
 """
 from app import (
     build_interface,


### PR DESCRIPTION
## Summary
- switch the Gradio backend to Whisper for ASR, NLLB for English translation, and an MT5 model for summarization
- simplify the interface to focus on English outputs and refresh descriptive copy accordingly
- document the new model choices and note the Colab launcher preloads Whisper, NLLB, and MT5 pipelines

## Testing
- python -m compileall app.py colab_app.py

------
https://chatgpt.com/codex/tasks/task_e_68e48df291c08331af3452182ac2a78a